### PR TITLE
Incremental writing

### DIFF
--- a/include/lcdfgif/gif.h
+++ b/include/lcdfgif/gif.h
@@ -288,7 +288,7 @@ int		Gif_FullWriteFile(Gif_Stream *gfs,
 Gif_Writer* Gif_WriteStart(Gif_Stream *gfs, const Gif_CompressInfo *gcinfo,
                             FILE *f, uint8_t isgif89a);
 int
-Gif_WriteImage(Gif_Stream *gfs, Gif_Writer *grr, Gif_Image *gfi);
+Gif_WriteImage(Gif_Stream *gfs, Gif_Writer *grr, Gif_Image *gfi, const Gif_CompressInfo *gcinfo);
 void    Gif_WriteEnd(Gif_Stream *gfs, Gif_Writer *grr);
 
 #define	Gif_ReadFile(f)		Gif_FullReadFile((f),GIF_READ_UNCOMPRESSED,0,0)

--- a/include/lcdfgif/gif.h
+++ b/include/lcdfgif/gif.h
@@ -256,6 +256,9 @@ Gif_Extension*  Gif_GetExtension(Gif_Stream* gfs, int kind,
 
 /** READING AND WRITING **/
 
+struct Gif_Writer;
+typedef struct Gif_Writer Gif_Writer;
+
 struct Gif_Record {
     const unsigned char *data;
     uint32_t length;
@@ -281,6 +284,12 @@ Gif_Stream*	Gif_FullReadRecord(const Gif_Record* record, int flags,
 int		Gif_WriteFile(Gif_Stream *gfs, FILE *f);
 int		Gif_FullWriteFile(Gif_Stream *gfs,
 				  const Gif_CompressInfo *gcinfo, FILE *f);
+
+Gif_Writer* Gif_WriteStart(Gif_Stream *gfs, const Gif_CompressInfo *gcinfo,
+                            FILE *f, uint8_t isgif89a);
+int
+Gif_WriteImage(Gif_Stream *gfs, Gif_Writer *grr, Gif_Image *gfi);
+void    Gif_WriteEnd(Gif_Stream *gfs, Gif_Writer *grr);
 
 #define	Gif_ReadFile(f)		Gif_FullReadFile((f),GIF_READ_UNCOMPRESSED,0,0)
 #define	Gif_ReadRecord(r)	Gif_FullReadRecord((r),GIF_READ_UNCOMPRESSED,0,0)

--- a/src/gifwrite.c
+++ b/src/gifwrite.c
@@ -70,7 +70,7 @@ typedef struct Gif_CodeTable {
 } Gif_CodeTable;
 
 
-typedef struct Gif_Writer {
+struct Gif_Writer {
   FILE *f;
   uint8_t *v;
   uint32_t pos;
@@ -82,7 +82,7 @@ typedef struct Gif_Writer {
   int cleared;
   void (*byte_putter)(uint8_t, struct Gif_Writer *);
   void (*block_putter)(const uint8_t *, uint16_t, struct Gif_Writer *);
-} Gif_Writer;
+};
 
 
 #define gifputbyte(b, grr)	((*grr->byte_putter)(b, grr))

--- a/src/gifwrite.c
+++ b/src/gifwrite.c
@@ -145,6 +145,13 @@ gfc_init(Gif_CodeTable *gfc)
   return gfc->nodes && gfc->links;
 }
 
+static void
+gfc_deinit(Gif_CodeTable *gfc)
+{
+  Gif_DeleteArray(gfc->nodes);
+  Gif_DeleteArray(gfc->links);
+}
+
 static inline void
 gfc_clear(Gif_CodeTable *gfc, Gif_Code clear_code)
 {
@@ -565,8 +572,7 @@ Gif_FullCompressImage(Gif_Stream *gfs, Gif_Image *gfi,
 
  done:
   Gif_DeleteArray(grr.v);
-  Gif_DeleteArray(gfc.nodes);
-  Gif_DeleteArray(gfc.links);
+  gfc_deinit(&gfc);
   return grr.v != 0;
 }
 
@@ -869,8 +875,7 @@ write_gif(Gif_Stream *gfs, Gif_Writer *grr)
   ok = 1;
 
  done:
-  Gif_DeleteArray(gfc.nodes);
-  Gif_DeleteArray(gfc.links);
+  gfc_deinit(&gfc);
   return ok;
 }
 

--- a/src/gifwrite.c
+++ b/src/gifwrite.c
@@ -909,10 +909,11 @@ Gif_WriteStart(Gif_Stream *gfs, const Gif_CompressInfo *gcinfo, FILE *f, uint8_t
 /**
  * Write single image to disk. You must call this on all images in order they've been added to Gif_Stream.
  * If image isn't in the Gif_Stream it'll be added.
+ * gcinfo is optional.
  * Returns 0 on failure.
  */
 int
-Gif_WriteImage(Gif_Stream *gfs, Gif_Writer *grr, Gif_Image *gfi)
+Gif_WriteImage(Gif_Stream *gfs, Gif_Writer *grr, Gif_Image *gfi, const Gif_CompressInfo *gcinfo)
 {
   int i = Gif_ImageNumber(gfs, gfi);
   if (i < 0) {
@@ -924,6 +925,10 @@ Gif_WriteImage(Gif_Stream *gfs, Gif_Writer *grr, Gif_Image *gfi)
   Gif_CodeTable gfc;
   if (!gfc_init(&gfc))
     return 0;
+
+  if (gcinfo) {
+    grr->gcinfo = *gcinfo;
+  }
 
   int ok = write_gif_write_image_and_extensions(gfs, grr, &gfc, gfi, i);
 


### PR DESCRIPTION
Streaming writer. Allows outputting GIF immediately and doesn't require keeping all frames in memory at once. 

User can create each frame and free/recycle memory before writing next frame, so almost infinite gif streams are possible with constant memory usage.

```c
Gif_Writer *grr = Gif_WriteStart(gfs, gcinfo, fp, 1);
for(lots) {
    Gif_WriteImage(gfs, grr, gfi);
}
Gif_WriteEnd(gfs, grr);
```
