### PR TITLE
Avoid collision with OS X headers

### DIFF
--- a/src/gifsicle.c
+++ b/src/gifsicle.c
@@ -21,8 +21,9 @@
 # include <unistd.h>
 #endif
 
+#ifndef static_assert
 #define static_assert(x, msg) switch ((int) (x)) case 0: case !!((int) (x)):
-
+#endif
 
 Gt_Frame def_frame;
 


### PR DESCRIPTION
Fixes:

```c
gifsicle.c:24:9: warning: 'static_assert' macro redefined [-Wmacro-redefined]
#define static_assert(x, msg) switch ((int) (x)) case 0: case !!((int) (x)):
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/assert.h:107:9: note: previous definition is here
#define static_assert _Static_assert
```