### PR TITLE
Remove needless aliases for Gif_Free()

### DIFF
--- a/include/lcdfgif/gif.h
+++ b/include/lcdfgif/gif.h
@@ -310,8 +310,6 @@ void            Gif_Free(void* p);
 # define Gif_New(t)             ((t*) Gif_Realloc(0, sizeof(t), 1, __FILE__, __LINE__))
 # define Gif_NewArray(t, n)     ((t*) Gif_Realloc(0, sizeof(t), (n), __FILE__, __LINE__))
 # define Gif_ReArray(p, t, n)   ((p)=(t*) Gif_Realloc((void*) (p), sizeof(t), (n), __FILE__, __LINE__))
-# define Gif_Delete(p)          Gif_Free((void*) (p))
-# define Gif_DeleteArray(p)     Gif_Free((void*) (p))
 #endif
 
 #ifdef __cplusplus

--- a/src/gifdiff.c
+++ b/src/gifdiff.c
@@ -386,12 +386,12 @@ compare(Gif_Stream *s1, Gif_Stream *s2)
 
   /* That's it! */
   Gif_DeleteColormap(newcm);
-  Gif_DeleteArray(gdata[0]);
-  Gif_DeleteArray(gdata[1]);
-  Gif_DeleteArray(glast[0]);
-  Gif_DeleteArray(glast[1]);
-  Gif_DeleteArray(scratch);
-  Gif_DeleteArray(line);
+  Gif_Free(gdata[0]);
+  Gif_Free(gdata[1]);
+  Gif_Free(glast[0]);
+  Gif_Free(glast[1]);
+  Gif_Free(scratch);
+  Gif_Free(line);
 
   return was_different ? DIFFERENT : SAME;
 }

--- a/src/giffunc.c
+++ b/src/giffunc.c
@@ -90,7 +90,7 @@ Gif_NewFullColormap(int count, int capacity)
 {
   Gif_Colormap *gfcm = Gif_New(Gif_Colormap);
   if (!gfcm || capacity <= 0 || count < 0) {
-    Gif_Delete(gfcm);
+    Gif_Free(gfcm);
     return 0;
   }
   if (count > capacity)
@@ -101,7 +101,7 @@ Gif_NewFullColormap(int count, int capacity)
   gfcm->refcount = 0;
   gfcm->userflags = 0;
   if (!gfcm->col) {
-    Gif_Delete(gfcm);
+    Gif_Free(gfcm);
     return 0;
   } else
     return gfcm;
@@ -131,7 +131,7 @@ Gif_NewExtension(int kind, const char* appname, int applength)
     if (appname) {
         gfex->appname = (char*) Gif_NewArray(char, applength + 1);
         if (!gfex->appname) {
-            Gif_Delete(gfex);
+            Gif_Free(gfex);
             return 0;
         }
         memcpy(gfex->appname, appname, applength);
@@ -265,7 +265,7 @@ Gif_AddComment(Gif_Comment *gfcom, const char *x, int xlen)
     return 0;
   memcpy(new_x, x, xlen);
   if (Gif_AddCommentTake(gfcom, new_x, xlen) == 0) {
-    Gif_DeleteArray(new_x);
+    Gif_Free(new_x);
     return 0;
   } else
     return 1;
@@ -497,7 +497,7 @@ Gif_DeleteStream(Gif_Stream *gfs)
 
   for (i = 0; i < gfs->nimages; i++)
     Gif_DeleteImage(gfs->images[i]);
-  Gif_DeleteArray(gfs->images);
+  Gif_Free(gfs->images);
 
   Gif_DeleteColormap(gfs->global);
 
@@ -508,7 +508,7 @@ Gif_DeleteStream(Gif_Stream *gfs)
   for (hook = all_hooks; hook; hook = hook->next)
     if (hook->kind == GIF_T_STREAM)
       (*hook->func)(GIF_T_STREAM, gfs, hook->callback_data);
-  Gif_Delete(gfs);
+  Gif_Free(gfs);
 }
 
 
@@ -523,19 +523,19 @@ Gif_DeleteImage(Gif_Image *gfi)
     if (hook->kind == GIF_T_IMAGE)
       (*hook->func)(GIF_T_IMAGE, gfi, hook->callback_data);
 
-  Gif_DeleteArray(gfi->identifier);
+  Gif_Free(gfi->identifier);
   Gif_DeleteComment(gfi->comment);
   while (gfi->extension_list)
       Gif_DeleteExtension(gfi->extension_list);
   Gif_DeleteColormap(gfi->local);
   if (gfi->image_data && gfi->free_image_data)
     (*gfi->free_image_data)((void *)gfi->image_data);
-  Gif_DeleteArray(gfi->img);
+  Gif_Free(gfi->img);
   if (gfi->compressed && gfi->free_compressed)
     (*gfi->free_compressed)((void *)gfi->compressed);
   if (gfi->user_data && gfi->free_user_data)
     (*gfi->free_user_data)(gfi->user_data);
-  Gif_Delete(gfi);
+  Gif_Free(gfi);
 }
 
 
@@ -550,8 +550,8 @@ Gif_DeleteColormap(Gif_Colormap *gfcm)
     if (hook->kind == GIF_T_COLORMAP)
       (*hook->func)(GIF_T_COLORMAP, gfcm, hook->callback_data);
 
-  Gif_DeleteArray(gfcm->col);
-  Gif_Delete(gfcm);
+  Gif_Free(gfcm->col);
+  Gif_Free(gfcm);
 }
 
 
@@ -562,10 +562,10 @@ Gif_DeleteComment(Gif_Comment *gfcom)
   if (!gfcom)
     return;
   for (i = 0; i < gfcom->count; i++)
-    Gif_DeleteArray(gfcom->str[i]);
-  Gif_DeleteArray(gfcom->str);
-  Gif_DeleteArray(gfcom->len);
-  Gif_Delete(gfcom);
+    Gif_Free(gfcom->str[i]);
+  Gif_Free(gfcom->str);
+  Gif_Free(gfcom->len);
+  Gif_Free(gfcom);
 }
 
 
@@ -576,7 +576,7 @@ Gif_DeleteExtension(Gif_Extension *gfex)
     return;
   if (gfex->data && gfex->free_data)
     (*gfex->free_data)(gfex->data);
-  Gif_DeleteArray(gfex->appname);
+  Gif_Free(gfex->appname);
   if (gfex->stream || gfex->image) {
       Gif_Extension** pprev;
       if (gfex->image)
@@ -588,7 +588,7 @@ Gif_DeleteExtension(Gif_Extension *gfex)
       if (*pprev)
           *pprev = gfex->next;
   }
-  Gif_Delete(gfex);
+  Gif_Free(gfex);
 }
 
 
@@ -620,7 +620,7 @@ Gif_RemoveDeletionHook(int kind, void (*func)(int, void *, void *), void *cb)
         prev->next = hook->next;
       else
         all_hooks = hook->next;
-      Gif_Delete(hook);
+      Gif_Free(hook);
       return;
     }
     prev = hook;
@@ -708,7 +708,7 @@ Gif_ReleaseCompressedImage(Gif_Image *gfi)
 void
 Gif_ReleaseUncompressedImage(Gif_Image *gfi)
 {
-  Gif_DeleteArray(gfi->img);
+  Gif_Free(gfi->img);
   if (gfi->image_data && gfi->free_image_data)
     (*gfi->free_image_data)(gfi->image_data);
   gfi->img = 0;

--- a/src/gifread.c
+++ b/src/gifread.c
@@ -540,9 +540,9 @@ Gif_FullUncompressImage(Gif_Stream* gfs, Gif_Image* gfi,
     ok = uncompress_image(&gfc, gfi, &grr);
   }
 
-  Gif_DeleteArray(gfc.prefix);
-  Gif_DeleteArray(gfc.suffix);
-  Gif_DeleteArray(gfc.length);
+  Gif_Free(gfc.prefix);
+  Gif_Free(gfc.suffix);
+  Gif_Free(gfc.length);
   if (gfc.errors[0] || gfc.errors[1])
       gif_read_error(&gfc, -1, 0);
   return ok && !gfc.errors[1];
@@ -709,7 +709,7 @@ read_unknown_extension(Gif_Context* gfc, Gif_Reader* grr,
 
  done:
     if (!gfex)
-        Gif_DeleteArray(data);
+        Gif_Free(data);
     while (block_len > 0) {
         uint8_t buffer[GIF_MAX_BLOCK];
         gifgetblock(buffer, block_len, grr);
@@ -888,10 +888,10 @@ read_gif(Gif_Reader *grr, int read_flags,
   }
 
   Gif_DeleteImage(gfi);
-  Gif_DeleteArray(last_name);
-  Gif_DeleteArray(gfc.prefix);
-  Gif_DeleteArray(gfc.suffix);
-  Gif_DeleteArray(gfc.length);
+  Gif_Free(last_name);
+  Gif_Free(gfc.prefix);
+  Gif_Free(gfc.suffix);
+  Gif_Free(gfc.length);
 
   if (gfs)
     gfs->errors = gfc.errors[1];

--- a/src/gifunopt.c
+++ b/src/gifunopt.c
@@ -134,12 +134,12 @@ unoptimize_image(Gif_Stream *gfs, Gif_Image *gfi, uint16_t *screen)
 
   put_image_in_screen(gfs, gfi, new_screen);
   if (!create_image_data(gfs, gfi, new_screen, new_data, &used_transparent)) {
-    Gif_DeleteArray(new_data);
+    Gif_Free(new_data);
     return 0;
   }
 
   if (gfi->disposal == GIF_DISPOSAL_PREVIOUS)
-    Gif_DeleteArray(new_screen);
+    Gif_Free(new_screen);
   else if (gfi->disposal == GIF_DISPOSAL_BACKGROUND)
     put_background_in_screen(gfs, gfi, screen);
 
@@ -223,7 +223,7 @@ Gif_FullUnoptimize(Gif_Stream *gfs, int flags)
         gfs->images[i]->disposal = GIF_DISPOSAL_BACKGROUND;
   }
 
-  Gif_DeleteArray(screen);
+  Gif_Free(screen);
   return ok;
 }
 

--- a/src/gifview.c
+++ b/src/gifview.c
@@ -505,9 +505,9 @@ delete_viewer(Gt_Viewer *viewer)
 
   Gif_DeleteXFrames(viewer->gfx, viewer->gfs, viewer->unoptimized_frames);
   Gif_DeleteStream(viewer->gfs);
-  Gif_DeleteArray(viewer->im);
+  Gif_Free(viewer->im);
   Gif_DeleteXContext(viewer->gfx);
-  Gif_Delete(viewer);
+  Gif_Free(viewer);
 }
 
 
@@ -853,7 +853,7 @@ set_viewer_name(Gt_Viewer *viewer, int slow_number)
   XSetWMIconName(viewer->display, viewer->window, &name_prop);
 
   XFree(name_prop.value);
-  Gif_DeleteArray(strs[0]);
+  Gif_Free(strs[0]);
 }
 
 static unsigned screen_memory_kb(const Gt_Viewer* viewer) {

--- a/src/gifwrite.c
+++ b/src/gifwrite.c
@@ -165,9 +165,9 @@ gif_writer_init(Gif_Writer* grr, FILE* f, const Gif_CompressInfo* gcinfo)
 static void
 gif_writer_cleanup(Gif_Writer* grr)
 {
-  Gif_DeleteArray(grr->v);
-  Gif_DeleteArray(grr->code_table.nodes);
-  Gif_DeleteArray(grr->code_table.links);
+  Gif_Free(grr->v);
+  Gif_Free(grr->code_table.nodes);
+  Gif_Free(grr->code_table.links);
 }
 
 
@@ -332,7 +332,7 @@ write_compressed_data(Gif_Image *gfi,
         goto error;
       memcpy(nbuf, buf, bufcap >> 3);
       if (buf != stack_buffer)
-        Gif_DeleteArray(buf);
+        Gif_Free(buf);
       buf = nbuf;
       bufcap = ncap;
     }
@@ -475,12 +475,12 @@ write_compressed_data(Gif_Image *gfi,
   gifputblock(buf, bufpos + 1, grr);
 
   if (buf != stack_buffer)
-    Gif_DeleteArray(buf);
+    Gif_Free(buf);
   return 1;
 
  error:
   if (buf != stack_buffer)
-    Gif_DeleteArray(buf);
+    Gif_Free(buf);
   return 0;
 }
 
@@ -887,7 +887,7 @@ Gif_IncrementalWriteFileInit(Gif_Stream* gfs, const Gif_CompressInfo* gcinfo,
 {
     Gif_Writer* grr = Gif_New(Gif_Writer);
     if (!grr || !gif_writer_init(grr, f, gcinfo)) {
-        Gif_Delete(grr);
+        Gif_Free(grr);
         return NULL;
     }
     gifputblock((const uint8_t *)"GIF89a", 6, grr);
@@ -922,7 +922,7 @@ Gif_IncrementalWriteComplete(Gif_Writer* grr, Gif_Stream* gfs)
         write_comment_extensions(gfs->end_comment, grr);
     gifputbyte(';', grr);
     gif_writer_cleanup(grr);
-    Gif_Delete(grr);
+    Gif_Free(grr);
     return 1;
 }
 

--- a/src/gifx.c
+++ b/src/gifx.c
@@ -70,7 +70,7 @@ load_closest(Gif_XContext *gfx)
   }
   gfx->nclosest = ncolor;
 
-  Gif_DeleteArray(color);
+  Gif_Free(color);
 }
 
 
@@ -169,8 +169,8 @@ create_x_colormap_extension(Gif_XContext *gfx, Gif_Colormap *gfcm)
     gfx->xcolormap = gfxc;
     return gfxc;
   } else {
-    Gif_Delete(gfxc);
-    Gif_DeleteArray(pixels);
+    Gif_Free(gfxc);
+    Gif_Free(pixels);
     return 0;
   }
 }
@@ -388,7 +388,7 @@ put_sub_image_colormap(Gif_XContext *gfx,
   XPutImage(gfx->display, pixmap, gfx->image_gc, ximage, 0, 0,
 	    pixmap_x, pixmap_y, width, height);
 
-  Gif_DeleteArray(xdata);
+  Gif_Free(xdata);
   ximage->data = 0; /* avoid freeing it again in XDestroyImage */
   XDestroyImage(ximage);
 
@@ -528,7 +528,7 @@ Gif_XSubMask(Gif_XContext* gfx, Gif_Stream* gfs, Gif_Image* gfi,
     XPutImage(gfx->display, pixmap, gfx->mask_gc, ximage, 0, 0, 0, 0,
 	      width, height);
 
-  Gif_DeleteArray(xdata);
+  Gif_Free(xdata);
   ximage->data = 0; /* avoid freeing it again in XDestroyImage */
   XDestroyImage(ximage);
 
@@ -665,7 +665,7 @@ Gif_DeleteXFrames(Gif_XContext *gfx, Gif_Stream *gfs, Gif_XFrame *fs)
   for (i = 0; i < gfs->nimages; ++i)
     if (fs[i].pixmap)
       XFreePixmap(gfx->display, fs[i].pixmap);
-  Gif_DeleteArray(fs);
+  Gif_Free(fs);
 }
 
 Pixmap
@@ -767,8 +767,8 @@ delete_xcolormap(Gif_XColormap *gfxc)
     prev->next = gfxc->next;
   else
     gfx->xcolormap = gfxc->next;
-  Gif_DeleteArray(gfxc->pixels);
-  Gif_Delete(gfxc);
+  Gif_Free(gfxc->pixels);
+  Gif_Free(gfxc);
 }
 
 static void
@@ -841,9 +841,9 @@ Gif_DeleteXContext(Gif_XContext *gfx)
     XFreeGC(gfx->display, gfx->image_gc);
   if (gfx->mask_gc)
     XFreeGC(gfx->display, gfx->mask_gc);
-  Gif_DeleteArray(gfx->closest);
+  Gif_Free(gfx->closest);
   Gif_RemoveDeletionHook(GIF_T_COLORMAP, delete_colormap_hook, gfx);
-  Gif_Delete(gfx);
+  Gif_Free(gfx);
 }
 
 

--- a/src/optimize.c
+++ b/src/optimize.c
@@ -82,8 +82,8 @@ void
 delete_opt_data(Gif_OptData *od)
 {
   if (!od) return;
-  Gif_DeleteArray(od->needed_colors);
-  Gif_Delete(od);
+  Gif_Free(od->needed_colors);
+  Gif_Free(od);
 }
 
 
@@ -290,7 +290,7 @@ prepare_colormap_map(Gif_Image *gfi, Gif_Colormap *into, uint8_t *need)
 
  error:
   /* If we get here, it failed! Return 0 and don't change global state. */
-  Gif_DeleteArray(map);
+  Gif_Free(map);
   return 0;
 }
 

--- a/src/opttemplate.c
+++ b/src/opttemplate.c
@@ -578,9 +578,9 @@ X(create_subimages)(Gif_Stream *gfs, int optimize_flags, int save_uncompressed)
     }
   }
 
-  Gif_DeleteArray(X(next_data));
+  Gif_Free(X(next_data));
   if (previous_data)
-      Gif_DeleteArray(previous_data);
+      Gif_Free(previous_data);
 }
 
 
@@ -699,9 +699,9 @@ X(create_out_global_map)(Gif_Stream *gfs)
     gfs->background = ordering[background];
 
   /* cleanup */
-  Gif_DeleteArray(penalty);
-  Gif_DeleteArray(permute);
-  Gif_DeleteArray(ordering);
+  Gif_Free(penalty);
+  Gif_Free(permute);
+  Gif_Free(ordering);
 }
 
 
@@ -921,7 +921,7 @@ X(create_new_image_data)(Gif_Stream *gfs, int optimize_flags)
 	  Gif_ReleaseCompressedImage(cur_gfi);
       }
 
-      Gif_DeleteArray(map);
+      Gif_Free(map);
     }
 
     delete_opt_data(opt);
@@ -944,7 +944,7 @@ X(create_new_image_data)(Gif_Stream *gfs, int optimize_flags)
   }
 
   if (previous_data)
-      Gif_DeleteArray(previous_data);
+      Gif_Free(previous_data);
 }
 
 
@@ -954,6 +954,6 @@ X(create_new_image_data)(Gif_Stream *gfs, int optimize_flags)
 
 static void
 X(finalize_optimizer_data)(void) {
-    Gif_DeleteArray(X(last_data));
-    Gif_DeleteArray(X(this_data));
+    Gif_Free(X(last_data));
+    Gif_Free(X(this_data));
 }

--- a/src/quantize.c
+++ b/src/quantize.c
@@ -121,8 +121,8 @@ void kc_set_gamma(int type, double gamma) {
         return;
     if (type == KC_GAMMA_SRGB) {
         if (gamma_tables[0] != srgb_gamma_table_256) {
-            Gif_DeleteArray(gamma_tables[0]);
-            Gif_DeleteArray(gamma_tables[1]);
+            Gif_Free(gamma_tables[0]);
+            Gif_Free(gamma_tables[1]);
         }
         gamma_tables[0] = (uint16_t*) srgb_gamma_table_256;
         gamma_tables[1] = (uint16_t*) srgb_revgamma_table_256;
@@ -203,7 +203,7 @@ void kchist_init(kchist* kch) {
 }
 
 void kchist_cleanup(kchist* kch) {
-    Gif_DeleteArray(kch->h);
+    Gif_Free(kch->h);
     kch->h = NULL;
 }
 
@@ -260,7 +260,7 @@ static void kchist_grow(kchist* kch) {
     for (i = 0; i != oldcapacity; ++i)
         if (oldh[i].count)
             kchist_add(kch, oldh[i].ka.k, oldh[i].count);
-    Gif_DeleteArray(oldh);
+    Gif_Free(oldh);
 }
 
 void kchist_compress(kchist* kch) {
@@ -507,7 +507,7 @@ Gif_Colormap* colormap_median_cut(kchist* kch, Gt_OutputData* od)
         adapt[i] = kc_togfcg(&kc);
     }
 
-    Gif_DeleteArray(slots);
+    Gif_Free(slots);
     gfcm->ncol = nadapt;
     return gfcm;
 }
@@ -532,10 +532,10 @@ void kcdiversity_init(kcdiversity* div, kchist* kch, int dodither) {
 }
 
 void kcdiversity_cleanup(kcdiversity* div) {
-    Gif_DeleteArray(div->closest);
-    Gif_DeleteArray(div->min_dist);
-    Gif_DeleteArray(div->min_dither_dist);
-    Gif_DeleteArray(div->chosen);
+    Gif_Free(div->closest);
+    Gif_Free(div->min_dist);
+    Gif_Free(div->min_dither_dist);
+    Gif_Free(div->chosen);
 }
 
 int kcdiversity_find_popular(kcdiversity* div) {
@@ -635,8 +635,8 @@ static void colormap_diversity_do_blend(kcdiversity* div) {
             for (k = 0; k != 3; ++k)
                 hist[match].ka.a[k] = (int) (di[i].a[k] / di[i].a[3]);
     }
-    Gif_DeleteArray(chosenmap);
-    Gif_DeleteArray(di);
+    Gif_Free(chosenmap);
+    Gif_Free(di);
 }
 
 
@@ -748,9 +748,9 @@ void kd3_init(kd3_tree* kd3, void (*transform)(kcolor*)) {
 }
 
 void kd3_cleanup(kd3_tree* kd3) {
-    Gif_DeleteArray(kd3->tree);
-    Gif_DeleteArray(kd3->ks);
-    Gif_DeleteArray(kd3->xradius);
+    Gif_Free(kd3->tree);
+    Gif_Free(kd3->ks);
+    Gif_Free(kd3->xradius);
 }
 
 void kd3_add_transformed(kd3_tree* kd3, const kcolor* k) {
@@ -761,8 +761,8 @@ void kd3_add_transformed(kd3_tree* kd3, const kcolor* k) {
     kd3->ks[kd3->nitems] = *k;
     ++kd3->nitems;
     if (kd3->tree) {
-        Gif_DeleteArray(kd3->tree);
-        Gif_DeleteArray(kd3->xradius);
+        Gif_Free(kd3->tree);
+        Gif_Free(kd3->xradius);
         kd3->tree = NULL;
         kd3->xradius = NULL;
     }
@@ -949,7 +949,7 @@ void kd3_build(kd3_tree* kd3) {
 #if ENABLE_THREADS
     pthread_mutex_unlock(&kd3_sort_lock);
 #endif
-    Gif_DeleteArray(perm);
+    Gif_Free(perm);
 }
 
 void kd3_init_build(kd3_tree* kd3, void (*transform)(kcolor*),
@@ -1184,8 +1184,8 @@ colormap_image_floyd_steinberg(Gif_Image *gfi, uint8_t *all_new_data,
   }
 
   /* delete temporary storage */
-  Gif_DeleteArray(err);
-  Gif_DeleteArray(err1);
+  Gif_Free(err);
+  Gif_Free(err1);
 }
 
 
@@ -1476,8 +1476,8 @@ static void colormap_image_ordered(Gif_Image* gfi, uint8_t* all_new_data,
         }
 
     /* delete temporary storage */
-    Gif_DeleteArray(ordered_dither_lum);
-    Gif_DeleteArray(plan);
+    Gif_Free(ordered_dither_lum);
+    Gif_Free(plan);
 }
 
 
@@ -1573,7 +1573,7 @@ colormap_stream(Gif_Stream* gfs, Gif_Colormap* new_cm, Gt_OutputData* od)
   if (new_cm->capacity < 256) {
     Gif_Color *x = Gif_NewArray(Gif_Color, 256);
     memcpy(x, new_col, sizeof(Gif_Color) * new_ncol);
-    Gif_DeleteArray(new_col);
+    Gif_Free(new_col);
     new_cm->col = new_col = x;
     new_cm->capacity = 256;
   }
@@ -1902,7 +1902,7 @@ static uint8_t* halftone_pixel_matrix(halftone_pixelinfo* hp,
         for (i = 0; i != w * h; ++i)
             m[4 + hp[i].x + hp[i].y*w] = i;
     }
-    Gif_DeleteArray(hp);
+    Gif_Free(hp);
     return m;
 }
 
@@ -1947,7 +1947,7 @@ int set_dither_type(Gt_OutputData* od, const char* name) {
 
     /* parse dither name */
     if (od->dither_type == dither_ordered_new)
-        Gif_DeleteArray(od->dither_data);
+        Gif_Free((char *)od->dither_data);
     od->dither_type = dither_none;
 
     if (strcmp(name, "none") == 0 || strcmp(name, "posterize") == 0)

--- a/src/support.c
+++ b/src/support.c
@@ -515,7 +515,7 @@ explode_filename(const char *filename, int number, const char *name, int max_nim
   int l = strlen(filename);
   l += name ? strlen(name) : 10;
 
-  Gif_Delete(s);
+  Gif_Free(s);
   s = Gif_NewArray(char, l + 3);
   if (name)
     sprintf(s, "%s.%s", filename, name);
@@ -1611,7 +1611,7 @@ merge_frame_interval(Gt_Frameset *fset, int f1, int f2,
 
     /* Names and comments */
     if (fr->name || fr->no_name) {
-      Gif_DeleteArray(desti->identifier);
+      Gif_Free(desti->identifier);
       desti->identifier = Gif_CopyString(fr->name);
     }
     if (fr->no_comments && desti->comment) {
@@ -1744,8 +1744,8 @@ blank_frameset(Gt_Frameset *fset, int f1, int f2, int delete_object)
       blank_frameset(FRAME(fset, i).nest, 0, 0, 1);
   }
   if (delete_object) {
-    Gif_DeleteArray(fset->f);
-    Gif_Delete(fset);
+    Gif_Free(fset->f);
+    Gif_Free(fset);
   }
 }
 

--- a/src/ungifwrt.c
+++ b/src/ungifwrt.c
@@ -123,8 +123,8 @@ gif_writer_init(Gif_Writer* grr, FILE* f, const Gif_CompressInfo* gcinfo)
 static void
 gif_writer_cleanup(Gif_Writer* grr)
 {
-  Gif_DeleteArray(grr->v);
-  Gif_DeleteArray(grr->rle_next);
+  Gif_Free(grr->v);
+  Gif_Free(grr->rle_next);
 }
 
 
@@ -214,7 +214,7 @@ write_compressed_data(Gif_Image *gfi,
         goto error;
       memcpy(nbuf, buf, bufcap >> 3);
       if (buf != stack_buffer)
-        Gif_DeleteArray(buf);
+        Gif_Free(buf);
       buf = nbuf;
       bufcap = ncap;
     }
@@ -373,12 +373,12 @@ write_compressed_data(Gif_Image *gfi,
   gifputblock(buf, bufpos + 1, grr);
 
   if (buf != stack_buffer)
-    Gif_DeleteArray(buf);
+    Gif_Free(buf);
   return 1;
 
  error:
   if (buf != stack_buffer)
-    Gif_DeleteArray(buf);
+    Gif_Free(buf);
   return 0;
 }
 
@@ -785,7 +785,7 @@ Gif_IncrementalWriteFileInit(Gif_Stream* gfs, const Gif_CompressInfo* gcinfo,
 {
     Gif_Writer* grr = Gif_New(Gif_Writer);
     if (!grr || !gif_writer_init(grr, f, gcinfo)) {
-        Gif_Delete(grr);
+        Gif_Free(grr);
         return NULL;
     }
     gifputblock((const uint8_t *)"GIF89a", 6, grr);
@@ -820,7 +820,7 @@ Gif_IncrementalWriteComplete(Gif_Writer* grr, Gif_Stream* gfs)
         write_comment_extensions(gfs->end_comment, grr);
     gifputbyte(';', grr);
     gif_writer_cleanup(grr);
-    Gif_Delete(grr);
+    Gif_Free(grr);
     return 1;
 }
 

--- a/src/xform.c
+++ b/src/xform.c
@@ -62,7 +62,7 @@ delete_color_transforms(Gt_ColorTransform *list, color_transform_func func)
     if (trav->func == func) {
       if (prev) prev->next = next;
       else list = next;
-      Gif_Delete(trav);
+      Gif_Free(trav);
     } else
       prev = trav;
     trav = next;
@@ -172,7 +172,7 @@ pipe_color_transformer(Gif_Colormap *gfcm, void *thunk)
   f = popen(new_command, "w");
   if (!f)
     fatal_error("can%,t run color transformation command: %s", strerror(errno));
-  Gif_DeleteArray(new_command);
+  Gif_Free(new_command);
 
   for (i = 0; i < gfcm->ncol; i++)
     fprintf(f, "%d %d %d\n", col[i].gfc_red, col[i].gfc_green, col[i].gfc_blue);
@@ -259,13 +259,13 @@ crop_image(Gif_Image* gfi, Gt_Frame* fr, int preserve_total_crop)
         for (j = 0; j < c.h; j++)
             gfi->img[j] = old_img[c.y + j] + c.x;
         gfi->img[c.h] = 0;
-        Gif_DeleteArray(old_img);
+        Gif_Free(old_img);
         gfi->width = c.w;
         gfi->height = c.h;
     } else if (preserve_total_crop)
         Gif_MakeImageEmpty(gfi);
     else {
-        Gif_DeleteArray(gfi->img);
+        Gif_Free(gfi->img);
         gfi->img = 0;
         gfi->width = gfi->height = 0;
     }
@@ -301,7 +301,7 @@ flip_image(Gif_Image* gfi, Gt_Frame *fr, int is_vert)
     gfi->left = fr->stream->screen_width - (gfi->left + width);
     if (fr->crop)
         fr->left_offset = fr->stream->screen_width - (fr->left_offset + fr->crop->w);
-    Gif_DeleteArray(buffer);
+    Gif_Free(buffer);
   }
 
   /* vertical flips */
@@ -313,7 +313,7 @@ flip_image(Gif_Image* gfi, Gt_Frame *fr, int is_vert)
     gfi->top = fr->stream->screen_height - (gfi->top + height);
     if (fr->crop)
         fr->top_offset = fr->stream->screen_height - (fr->top_offset + fr->crop->h);
-    Gif_DeleteArray(buffer);
+    Gif_Free(buffer);
   }
 }
 
@@ -404,8 +404,8 @@ static void kcscreen_init(kcscreen* kcs, Gif_Stream* gfs, int sw, int sh) {
 
 /* free memory associated with `kcs` */
 static void kcscreen_cleanup(kcscreen* kcs) {
-    Gif_DeleteArray(kcs->data);
-    Gif_DeleteArray(kcs->scratch);
+    Gif_Free(kcs->data);
+    Gif_Free(kcs->scratch);
 }
 
 /* apply image `gfi` to screen `kcs`, using the color array `ks` */
@@ -490,8 +490,8 @@ static void ksscreen_init(ksscreen* kss, Gif_Stream* gfs, int sw, int sh) {
 
 /* free memory associated with `kss` */
 static void ksscreen_cleanup(ksscreen* kss) {
-    Gif_DeleteArray(kss->data);
-    Gif_DeleteArray(kss->scratch);
+    Gif_Free(kss->data);
+    Gif_Free(kss->scratch);
 }
 
 /* apply image `gfi` to screen `kss`, using the color array `ks` */
@@ -601,8 +601,8 @@ static void sctx_cleanup(scale_context* sctx) {
     ksscreen_cleanup(&sctx->iscr);
     kcscreen_cleanup(&sctx->oscr);
     kcscreen_cleanup(&sctx->xscr);
-    Gif_DeleteArray(sctx->xweights.ws);
-    Gif_DeleteArray(sctx->yweights.ws);
+    Gif_Free(sctx->xweights.ws);
+    Gif_Free(sctx->yweights.ws);
 }
 
 static void scale_image_data_point(scale_context* sctx, Gif_Image* gfo) {
@@ -620,7 +620,7 @@ static void scale_image_data_point(scale_context* sctx, Gif_Image* gfo) {
             *data = in_line[xoff[xo]];
     }
 
-    Gif_DeleteArray(xoff);
+    Gif_Free(xoff);
 }
 
 static void scale_image_prepare(scale_context* sctx) {
@@ -844,9 +844,9 @@ static void scale_image_data_box(scale_context* sctx, Gif_Image* gfo) {
 
     scale_image_complete(sctx, gfo);
 
-    Gif_DeleteArray(xoff);
-    Gif_DeleteArray(sc);
-    Gif_DeleteArray(nsc);
+    Gif_Free(xoff);
+    Gif_Free(sc);
+    Gif_Free(nsc);
 }
 
 static inline float mix_factor(int val, const float bounds[2]) {
@@ -911,8 +911,8 @@ static void scale_image_data_mix(scale_context* sctx, Gif_Image* gfo) {
 
     scale_image_complete(sctx, gfo);
 
-    Gif_DeleteArray(sc);
-    Gif_DeleteArray(mix);
+    Gif_Free(sc);
+    Gif_Free(mix);
 }
 
 
@@ -1063,8 +1063,8 @@ static void scale_image_data_weighted(scale_context* sctx, Gif_Image* gfo,
 
     scale_image_complete(sctx, gfo);
 
-    Gif_DeleteArray(sc);
-    Gif_DeleteArray(kcx);
+    Gif_Free(sc);
+    Gif_Free(kcx);
 }
 
 static void scale_image_data_catrom(scale_context* sctx, Gif_Image* gfo) {
@@ -1297,7 +1297,7 @@ resize_stream(Gif_Stream* gfs,
         }
         for (i = 0; i < nthreads; ++i)
             pthread_join(ctx[i].threadid, NULL);
-        Gif_DeleteArray(ctx);
+        Gif_Free(ctx);
     }
 #else
     nthreads = 1;


### PR DESCRIPTION
This is the first step in simplifying gifsicle's freeing logic.
Gif_Delete() and Gif_DeleteArray() are just macros defined as
Gif_Free().

No binary change.