### PR TITLE
Fix threaded complex condition

### DIFF
--- a/src/xform.c
+++ b/src/xform.c
@@ -1272,12 +1272,13 @@ resize_stream(Gif_Stream* gfs,
         nthreads = gfs->nimages;
 #if ENABLE_THREADS
     /* Threaded resize only works if the input image is unoptimized. */
-    for (i = 0; nthreads > 1 && i < gfs->nimages - 1; ++i)
+    for (i = 0; nthreads > 1 && i < gfs->nimages; ++i)
         if (gfs->images[i]->left != 0
             || gfs->images[i]->top != 0
             || gfs->images[i]->width != gfs->screen_width
             || gfs->images[i]->height != gfs->screen_height
-            || (gfs->images[i]->disposal != GIF_DISPOSAL_BACKGROUND
+            || (i != gfs->nimages
+                && gfs->images[i]->disposal != GIF_DISPOSAL_BACKGROUND
                 && gfs->images[i+1]->transparent >= 0)) {
             warning(1, "image too complex for multithreaded resize, using 1 thread\n  (Try running the GIF through %<gifsicle -U%>.)");
             nthreads = 1;

--- a/src/xform.c
+++ b/src/xform.c
@@ -1277,7 +1277,7 @@ resize_stream(Gif_Stream* gfs,
             || gfs->images[i]->top != 0
             || gfs->images[i]->width != gfs->screen_width
             || gfs->images[i]->height != gfs->screen_height
-            || (i != gfs->nimages
+            || (i != gfs->nimages - 1
                 && gfs->images[i]->disposal != GIF_DISPOSAL_BACKGROUND
                 && gfs->images[i+1]->transparent >= 0)) {
             warning(1, "image too complex for multithreaded resize, using 1 thread\n  (Try running the GIF through %<gifsicle -U%>.)");


### PR DESCRIPTION
Re-submitting after fixing off-by-one error.
I believe this should fix the first case in issue #60
The condition to check if threaded resizing can be used does not check the size/position of the last frame currently.

@wilkesybear