### PR TITLE
Fixed infinite looping when copying a gif's extension list

### DIFF
--- a/src/giffunc.c
+++ b/src/giffunc.c
@@ -417,6 +417,7 @@ Gif_CopyImage(Gif_Image *src)
           if (!dstex)
               goto failure;
           Gif_AddExtension(NULL, dest, dstex);
+          gfex = gfex->next;
       }
   }
 


### PR DESCRIPTION
Gif_CopyImage currently runs into an infinite loop when copying from an image with an extension list