### PR TITLE
Makefile for MinGW GCC

### DIFF
--- a/src/Makefile.mingw
+++ b/src/Makefile.mingw
@@ -1,0 +1,66 @@
+# Win32 Makefile originally by Emil Mikulic <darkmoon@connexus.net.au>
+# Updates by Eddie Kohler <ekohler@gmail.com> and
+# Steven Marthouse <comments@vrml3d.com>
+
+# ----------------------------------------------------------
+# Makefile adapted for MinGW GCC Compiler
+# José Manuel Muñoz <jmlosvillares@correo.ugr.es>
+# ----------------------------------------------------------
+
+
+# *** MAKING UNGIFSICLE ***
+# If `GIFWRITE_OBJ' is defined to `gifwrite.o', Gifsicle will use
+# Unisys-patented LZW compression. If it is defined to `ungifwrt.o', it
+# will use unpatented run-length compression, which creates larger GIFs but
+# is completely free software. If you downloaded the ungifsicle package,
+# which doesn't have `gifwrite.c', you MUST define `GIFWRITE_OBJ' to
+# `ungifwrt.o' by commenting the first line below and uncommenting the
+# second.
+GIFWRITE_OBJ = gifwrite.o
+#GIFWRITE_OBJ = ungifwrt.o
+
+# *** SUPPORTING WILDCARD EXPANSION ***
+# MinGW seems to include support for this by itself.
+
+CC = gcc
+MINGWFLAGS = -DHAVE_UINTPTR_T -DHAVE_INTTYPES_H
+CFLAGS = -I.. -I..\include -DHAVE_CONFIG_H=1 -D_CONSOLE -O2 $(MINGWFLAGS)
+
+GIFSICLE_OBJS = clp.o fmalloc.o giffunc.o gifread.o gifunopt.o \
+	$(GIFWRITE_OBJ) merge.o optimize.o quantize.o support.o \
+	xform.o gifsicle.o
+
+GIFDIFF_OBJS = clp.o fmalloc.o giffunc.o gifread.o gifdiff.o
+
+
+all: gifsicle.exe gifdiff.exe
+
+gifsicle.exe: $(GIFSICLE_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(GIFSICLE_OBJS)
+
+gifdiff.exe: $(GIFDIFF_OBJS)
+	$(CC) $(CFLAGS) -o $@ $(GIFDIFF_OBJS)
+
+clp.o: ..\config.h ..\include\lcdf\clp.h clp.c
+
+fmalloc.o: ..\config.h fmalloc.c
+
+giffunc.o: ..\config.h giffunc.c ..\include\lcdfgif\gif.h
+gifread.o: ..\config.h gifread.c ..\include\lcdfgif\gif.h
+gifwrite.o: ..\config.h gifwrite.c ..\include\lcdfgif\gif.h
+ungifwrt.o: ..\config.h ungifwrt.c ..\include\lcdfgif\gif.h
+gifunopt.o: ..\config.h gifunopt.c ..\include\lcdfgif\gif.h
+
+merge.o: ..\config.h gifsicle.h merge.c
+optimize.o: ..\config.h gifsicle.h optimize.c
+quantize.o: ..\config.h gifsicle.h quantize.c
+support.o: ..\config.h gifsicle.h support.c
+xform.o: ..\config.h gifsicle.h xform.c
+gifsicle.o: ..\config.h gifsicle.h gifsicle.c
+
+..\config.h: win32cfg.h
+	copy win32cfg.h ..\config.h
+
+clean:
+	del *.o
+	del *.exe


### PR DESCRIPTION
MinGW GCC is yet another C compiler for Windows. This Makefile works for MinGW GCC by changing to `src` folder and typing:

    make -f Makefile.mingw

I tried compiling gifsicle in a 32-bit machine using gcc version 3 and a 64-bit machine with gcc version 6.2.0. The compiled programs were able to successfully optimize a bunch of files in batch mode using a wildcard (`gifsicle -bO *.gif`). I do not know whether further tests would be needed.

If this pull request is accepted, the README might need be modified in order to mention this file and the supported compiler.

Interestingly enough, some minor changes in preprocessor code within a couple of other files were required to make this Makefile work when using the latest release, but they have already been done since then.