### PR TITLE
Fix URL of logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![gifsicle-logo](https://raw.githubusercontent.com/kohler/gifsicle/master/logo.gif)
+![gifsicle-logo](/../master/logo.gif)
 
 Gifsicle
 ========


### PR DESCRIPTION
Use the user-agnostic form of `/../[BRANCH]/path.gif` to future-proof
this against ownership change.