### PR TITLE
Suggest `less` to view help instead of `more`

### DIFF
--- a/src/support.c
+++ b/src/support.c
@@ -235,7 +235,7 @@ Whole-GIF options: Also --no-OPTION.\n\
                                 be 'web', 'gray', 'bw', or a GIF file.\n\n");
   printf("\
 Report bugs to <ekohler@gmail.com>.\n\
-Too much information? Try '%s --help | more'.\n", program_name);
+Too much information? Try '%s --help | less'.\n", program_name);
 #ifdef GIF_UNGIF
   printf("\
 This version of Gifsicle writes uncompressed GIFs, which can be far larger\n\


### PR DESCRIPTION
This PR suggests using `less` to view the help text instead of `more`.

From [`more`'s `man` page](https://man7.org/linux/man-pages/man1/more.1.html#DESCRIPTION):
```
[more] is especially primitive. Users should realize that 
less(1) provides more(1) emulation plus extensive 
enhancements.
```

From [`less`'s `man` page](https://man7.org/linux/man-pages/man1/less.1.html#DESCRIPTION):
```
Less is a program similar to more (1), but which allows 
backward movement in the file as well as forward movement. 
Also, less does not have to read the entire input file 
before starting, so with large input files it starts up 
faster than text editors like vi (1). Less uses termcap (or 
terminfo on some systems), so it can run on a variety of 
terminals. There is even limited support for hardcopy 
terminals. (On a hardcopy terminal, lines which should be 
printed at the top of the screen are prefixed with a caret.)

Commands are based on both more and vi.
```
