### PR TITLE
bug fix due to abnormal GIF file's width

### DIFF
--- a/src/merge.c
+++ b/src/merge.c
@@ -376,6 +376,10 @@ merge_image(Gif_Stream *dest, Gif_Stream *src, Gif_Image *srci,
       for (j = 0; j < desti->height; j++) {
         uint8_t *srcdata = srci->img[j];
         uint8_t *destdata = desti->img[j];
+	if (desti->width > 255) {
+	  printf("Gif file's width is abnormal!\n");
+	  exit(0);
+	}
         for (i = 0; i < desti->width; i++, srcdata++, destdata++)
           *destdata = map[*srcdata];
       }


### PR DESCRIPTION
## System configuration

- gifsicle version: 1.93
- Used arguments: --delay=10 --loop
- Environment (Operating system, version and so on): Ubuntu 18.04 64bit

Abnormal memory access occurs due to the abnormal width of the GIF file.
I've attached the file. Please download and check the file.
[gifsicle_PoC.zip](https://github.com/kohler/gifsicle/files/6938355/gifsicle_PoC.zip)

I've also developed a patch code to mitigate abnormal memory access. 
Please check it.