### PR TITLE
Change help section "verbose" output to match the manpage and program behavior

### DIFF
--- a/src/support.c
+++ b/src/support.c
@@ -157,7 +157,7 @@ General options: Also --no-OPTION for info and verbose.\n\
       --color-info, --cinfo     --info plus colormap details.\n\
       --extension-info, --xinfo --info plus extension details.\n\
       --size-info, --sinfo      --info plus compression information.\n\
-  -V, --verbose                 Prints progress information.\n",
+  -V, --verbose                 Prints progress information (files read and written).\n",
     q0, q1);
   printf("\
   -h, --help                    Print this message and exit.\n\


### PR DESCRIPTION
Changes help section to say that verbose is only provides information about which files are being (or have been) read/written to, which makes it match the manpage and program behavior.

Without this, the user will likely expect something more verbose that tells one about how the task is progressing.