### PR TITLE
Fix Makefile.w32 to include kcolor.obj (resolves #215)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ stamp-h*
 ungifsicle-*.rpm
 ungifsicle-*.tar.gz
 compile
+*.obj
+*.exe
+*.pdb
+*.ilk
+*.idb

--- a/src/Makefile.w32
+++ b/src/Makefile.w32
@@ -24,9 +24,9 @@ LDLIBS = setargv.obj
 
 GIFSICLE_OBJS = clp.obj fmalloc.obj giffunc.obj gifread.obj gifunopt.obj \
 	$(GIFWRITE_OBJ) merge.obj optimize.obj quantize.obj support.obj \
-	xform.obj gifsicle.obj
+	xform.obj gifsicle.obj kcolor.obj
 
-GIFDIFF_OBJS = clp.obj fmalloc.obj giffunc.obj gifread.obj gifdiff.obj
+GIFDIFF_OBJS = clp.obj fmalloc.obj giffunc.obj gifread.obj gifdiff.obj kcolor.obj
 
 .c.obj:
 	$(CC) $(CFLAGS) /c $<


### PR DESCRIPTION
Makefile.w32 did not include kcolor.obj in GIFSICLE_OBJS and GIFDIFF_OBJS, causing linker errors when building on Windows with Visual C. This patch adds kcolor.obj so symbols like gamma_tables and kchist_* are correctly linked.

Resolves #215